### PR TITLE
Fix texture crash, emoji rendering, CME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog — Figura 1.21.11
+
+All notable changes since the initial 1.21.11 port.
+
+## Bug Fixes
+
+### Rendering
+- **Fix cape visibility** — Capes were not rendering correctly for players
+- **Fix skull block entity rendering** — Skull blocks placed in the world were not rendering properly
+- **Fix hand-held/hotbar skull rendering** — First-person held heads and hotbar skull items were broken
+- **Fix duplicate ghost skull with shaders** — A ghost skull would appear when using Iris/Optifine shader packs
+
+### Textures & Crashes
+- **Fix texture crash on avatar reload** — `Texture view does not exist` crash when clearing/reloading avatars. The GPU texture was being freed while in-flight render batches (Sodium shadow passes, ImmediatelyFast batched draws, Iris) still referenced it. Texture GPU resources are now left for GC cleanup instead of manual release during avatar unload
+- **Fix missing textures on resource reload** — `FiguraTexture.close()` now only releases GPU resources (not NativeImage data), so `apply()` can re-upload the texture after a resource pack reload
+- **Fix texture cleanup race condition** — Texture destruction is always deferred to the render thread to prevent async threads from destroying textures mid-frame
+
+### Emojis
+- **Fix animated emoji metadata being null** — `GlyphInfo.simple()` creates lambda instances with no `equals/hashCode`, so the HashMap in `GlyphStitcherMixin` never matched. Added a fallback in `FontSetMixin.afterComputeGlyphInfo` that directly sets up emoji metadata after glyph baking
+- **Fix animated emoji UV with ImmediatelyFast** — Replaced hardcoded `8f / getFontWidthIMF()` with dynamic `(u1 - u0) / frames` for per-frame UV width, making emoji animation independent of font atlas size (works with vanilla 256px, IF's 2048px, or any other size)
+
+### Stability
+- **Fix ConcurrentModificationException in feature renderer** — Figura callbacks during `renderModel` could indirectly submit new translucent models, modifying the list while iterating. Added defensive copy in `ModelFeatureRendererMixin.renderTranslucents`
+
+### CI/Build
+- **Fix gradlew executable permission** — Linux CI builds would fail due to missing execute permission on `gradlew`

--- a/common/src/main/java/org/figuramc/figura/mixin/font/BakedSheetGlyphMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/font/BakedSheetGlyphMixin.java
@@ -2,7 +2,6 @@ package org.figuramc.figura.mixin.font;
 
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.gui.font.glyphs.BakedSheetGlyph;
-import org.figuramc.figura.compat.ImmediatelyFastCompat;
 import org.figuramc.figura.ducks.BakedGlyphAccessor;
 import org.figuramc.figura.font.EmojiContainer;
 import org.figuramc.figura.font.EmojiMetadata;
@@ -58,7 +57,7 @@ public abstract class BakedSheetGlyphMixin implements BakedGlyphAccessor {
         float n = italic ? 1.0f - 0.25f * j : 0f;
         float q = bold ? 0.1F : 0.0F;
 
-        final float singleWidth = 8f / ImmediatelyFastCompat.getFontWidthIMF();
+        final float singleWidth = (u1 - u0) / figura$metadata.frames;
         float shift = singleWidth * figura$metadata.getCurrentFrame();
 
         float u = u0 + shift;

--- a/common/src/main/java/org/figuramc/figura/mixin/font/FontSet$SelectedGlyphsAccessor.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/font/FontSet$SelectedGlyphsAccessor.java
@@ -1,0 +1,17 @@
+package org.figuramc.figura.mixin.font;
+
+import net.minecraft.client.gui.font.glyphs.BakedGlyph;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.function.Supplier;
+
+@Mixin(targets = "net.minecraft.client.gui.font.FontSet$SelectedGlyphs")
+public interface FontSet$SelectedGlyphsAccessor {
+
+    @Accessor("any")
+    Supplier<BakedGlyph> figura$getAny();
+
+    @Accessor("nonFishy")
+    Supplier<BakedGlyph> figura$getNonFishy();
+}

--- a/common/src/main/java/org/figuramc/figura/mixin/font/FontSetMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/font/FontSetMixin.java
@@ -5,9 +5,13 @@ import com.mojang.blaze3d.font.GlyphProvider;
 import com.mojang.blaze3d.font.UnbakedGlyph;
 import net.minecraft.client.gui.font.FontSet;
 import net.minecraft.client.gui.font.GlyphStitcher;
+import net.minecraft.client.gui.font.glyphs.BakedGlyph;
 import net.minecraft.client.gui.font.providers.BitmapProvider;
+import org.figuramc.figura.ducks.BakedGlyphAccessor;
 import org.figuramc.figura.ducks.BitmapProviderGlyphAccessor;
 import org.figuramc.figura.ducks.GlyphStitcherExtension;
+import org.figuramc.figura.font.Emojis;
+import org.figuramc.figura.font.EmojiContainer;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,6 +25,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 @Mixin(FontSet.class)
 public abstract class FontSetMixin {
@@ -45,6 +50,31 @@ public abstract class FontSetMixin {
 
         if (unbakedGlyph != null) {
             ((GlyphStitcherExtension) stitcher).addCodePoint(unbakedGlyph.info(), codePoint);
+        }
+    }
+
+    // The GlyphStitcher HashMap approach above doesn't work for all glyphs because
+    // GlyphInfo.simple() creates lambda instances with no equals/hashCode.
+    // This fallback ensures emoji metadata is always set by force-baking after computeGlyphInfo.
+    @Inject(method = "computeGlyphInfo", at = @At("RETURN"))
+    public void afterComputeGlyphInfo(int codePoint, CallbackInfoReturnable<?> cir) {
+        if (!figura$isEmojiFont()) return;
+        Object result = cir.getReturnValue();
+        if (result == null) return;
+        EmojiContainer container = Emojis.getCategoryByFont(((GlyphStitcherAccessor) stitcher).getName());
+        if (container == null) return;
+
+        FontSet$SelectedGlyphsAccessor accessor = (FontSet$SelectedGlyphsAccessor) result;
+        figura$setupEmojiOnGlyph(accessor.figura$getAny(), container, codePoint);
+        figura$setupEmojiOnGlyph(accessor.figura$getNonFishy(), container, codePoint);
+    }
+
+    @Unique
+    private void figura$setupEmojiOnGlyph(Supplier<BakedGlyph> supplier, EmojiContainer container, int codePoint) {
+        if (supplier == null) return;
+        BakedGlyph glyph = supplier.get();
+        if (glyph instanceof BakedGlyphAccessor bakedAccessor) {
+            bakedAccessor.figura$setupEmoji(container, codePoint);
         }
     }
 

--- a/common/src/main/java/org/figuramc/figura/mixin/render/feature/ModelFeatureRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/feature/ModelFeatureRendererMixin.java
@@ -1,5 +1,7 @@
 package org.figuramc.figura.mixin.render.feature;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -16,6 +18,10 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 // this method runs callbacks for Models before and after rendering, as well as before animation setup if they exist
 @Mixin(ModelFeatureRenderer.class)
@@ -67,5 +73,12 @@ public class ModelFeatureRendererMixin {
             callback.run();
 
         callBackExtension.figura$getPostRenderingCallbacks().clear();
+    }
+
+    // Defensive copy: Figura callbacks during renderModel can indirectly cause new
+    // translucent model submissions, modifying the list while it's being iterated.
+    @WrapOperation(method = "renderTranslucents", at = @At(value = "INVOKE", target = "Ljava/util/List;iterator()Ljava/util/Iterator;"))
+    private Iterator<?> figura$safeTranslucentIterator(List<?> list, Operation<Iterator<?>> original) {
+        return new ArrayList<>(list).iterator();
     }
 }

--- a/common/src/main/java/org/figuramc/figura/model/rendering/FiguraRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/FiguraRenderer.java
@@ -145,13 +145,19 @@ public abstract class FiguraRenderer {
         for (FiguraTextureSet set : textureSets)
             set.clean();
         for (FiguraTexture texture : customTextures.values())
-            texture.close();
+            texture.closeFromRenderThread();
     }
 
     public void invalidate() {
         this.dirty = true;
-        if (!this.isRendering)
-            clean();
+        if (!this.isRendering) {
+            // Always defer clean() to the render thread to avoid destroying
+            // textures while ImmediatelyFast still has batched draw references
+            Minecraft.getInstance().execute(() -> {
+                this.dirty = false;
+                clean();
+            });
+        }
     }
 
     public void sortParts() {

--- a/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateFiguraRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateFiguraRenderer.java
@@ -198,8 +198,10 @@ public class ImmediateFiguraRenderer extends FiguraRenderer {
         }
 
         this.isRendering = false;
-        if (this.dirty)
+        if (this.dirty) {
+            this.dirty = false;
             clean();
+        }
 
         return prev - Math.max(remainingComplexity[0], 0);
     }

--- a/common/src/main/java/org/figuramc/figura/model/rendering/texture/FiguraTexture.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/texture/FiguraTexture.java
@@ -107,27 +107,44 @@ public class FiguraTexture extends SimpleTexture {
 
     @Override
     public void apply(TextureContents textureContents) {
+        // MC resource reload — old GPU texture was released, force re-upload
+        isClosed = false;
+        dirty = true;
         uploadIfDirty(false, false);
     }
 
     public void closeFromRenderThread() {
-        Minecraft.getInstance().execute(this::close);
+        Minecraft.getInstance().execute(this::destroy);
     }
 
     @Override
     public void close() {
-        // Make sure it doesn't close twice (minecraft tries to close the texture when reloading textures
-        if (isClosed) return;
+        // Called by MC during resource reload — only release GPU resources.
+        // Keep NativeImage alive so apply() can re-upload the texture.
+        registered = false;
+        // Remove from TextureManager BEFORE releasing GPU resources to prevent
+        // lookups returning a texture with a null textureView (causes crash with ImmediatelyFast)
+        ((TextureManagerAccessor) Minecraft.getInstance().getTextureManager()).getByPath().remove(this.getLocation());
+        super.close();
+    }
 
+    /**
+     * Full cleanup — closes NativeImage pixel data and unregisters from TextureManager.
+     * Called when Figura is permanently done with this texture (avatar unload).
+     * Does NOT release GPU resources (texture/textureView) to avoid crashing
+     * in-flight render batches that may still reference this texture's view.
+     * GPU resources will be freed by GC via MC's Cleaner mechanism.
+     */
+    public void destroy() {
+        if (isClosed) return;
         isClosed = true;
 
-        // Close native images
         if (nativeImageTexture != null)
             nativeImageTexture.close();
         if (backup != null)
             backup.close();
 
-        super.close();
+        registered = false;
         ((TextureManagerAccessor) Minecraft.getInstance().getTextureManager()).getByPath().remove(this.getLocation());
     }
 

--- a/common/src/main/resources/figura-common.mixins.json
+++ b/common/src/main/resources/figura-common.mixins.json
@@ -35,6 +35,7 @@
     "font.BakedSheetGlyphMixin",
     "font.BitmapGlyphMixin",
     "font.FontAccessor",
+    "font.FontSet$SelectedGlyphsAccessor",
     "font.FontSet$SourceAccessor",
     "font.FontSetMixin",
     "font.GlyphStitcherAccessor",


### PR DESCRIPTION
- Fix 'Texture view does not exist' crash on avatar reload (race with Sodium/Iris/IF)

- Fix missing textures after resource reload (split close/destroy lifecycle)

- Fix animated emoji metadata null (bypass broken GlyphInfo HashMap)

- Fix ConcurrentModificationException in ModelFeatureRendererMixin

- Defer texture cleanup to render thread to prevent async destruction